### PR TITLE
Add support for godep to pin project dependencies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,9 @@ go:
   - 1.2
 
 before_install:
+  - export PATH=$HOME/gopath/bin:$PATH
   - sudo apt-get update
   - sudo apt-get install -yq libgeos-dev
+  - go get github.com/tools/godep
 
-script: go test eco/*
+script: godep go test eco/*

--- a/Godeps
+++ b/Godeps
@@ -1,0 +1,18 @@
+{
+	"ImportPath": "github.com/OpenTreeMap/ecobenefits",
+	"GoVersion": "go1.2.2",
+	"Deps": [
+		{
+			"ImportPath": "code.google.com/p/gcfg",
+			"Rev": "c2d3050044d05357eaf6c3547249ba57c5e235cb"
+		},
+		{
+			"ImportPath": "github.com/lib/pq",
+			"Rev": "3c5c5bd6383b42aec97b5aa39fba2cddd35aea36"
+		},
+		{
+			"ImportPath": "github.com/ungerik/go-rest",
+			"Rev": "c3ee1de9e2197fe2812b818f25d2fc59fab9a13e"
+		}
+	]
+}

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# ecoservice
+# ecoservice [![Build Status](https://travis-ci.org/OpenTreeMap/ecobenefits.svg?branch=master)](https://travis-ci.org/OpenTreeMap/ecobenefits)
 
 REST services for calculating eco benefits for trees in an [OpenTreeMap](https://github.com/OpenTreeMap) database.
 

--- a/bootstrap
+++ b/bootstrap
@@ -1,6 +1,10 @@
-#!/bin/sh -e
+#!/bin/bash
+
+set -e
+set -x
+
 apt-get update
-apt-get install -y libgeos-dev git wget
+apt-get install -y libgeos-dev git wget mercurial
 
 VERSION=1.2.2
 OS=linux

--- a/build
+++ b/build
@@ -1,7 +1,11 @@
-#!/bin/sh -e
+#!/bin/bash
+
+set -e
+set -x
 
 export GOBIN=${PWD}/bin
 export GOPATH=${PWD}/gopath
+export PATH=${PATH}:/usr/local/go/bin:${GOBIN}
 
 rm -rf bin
 rm -rf gopath
@@ -9,9 +13,11 @@ mkdir -p gopath/src/github.com/azavea/ecobenefits
 cp main.go gopath/src/github.com/azavea/ecobenefits
 cp -r eco gopath/src/github.com/azavea/ecobenefits/eco
 go get -v github.com/azavea/ecobenefits
+go get -v github.com/tools/godep
 
 go clean
-go test eco/*
+godep restore
+godep go test eco/*
 go install github.com/azavea/ecobenefits
 cp -r data bin/data
 cp config.gcfg.template bin


### PR DESCRIPTION
[godep](https://github.com/tools/godep) appears to be solid choice for pinning Go project dependencies. This pull request contains a `Godeps` file with SHAs of dependency revisions. Tests were run at the specified SHAs before freezing.

To restore the state frozen in `Godeps`, first install `godep`:

``` bash
$ go get github.com/tools/godep
```

Then, run:

``` bash
$ godep restore
```

**Note**: This is going to change the `HEAD` of dependencies in `$GOPATH/src`.

As you make changes to the code, use the following command to invoke the test suite:

``` bash
$ godep go test
```

To [add](https://github.com/tools/godep#add-a-dependency) or [update](https://github.com/tools/godep#update-a-dependency) dependencies, please see the `godep` documentation.

Aims to resolve: https://github.com/OpenTreeMap/ecobenefits/issues/29
