### PR TITLE
Remove Godep binary from output bin directory

### DIFF
--- a/build
+++ b/build
@@ -21,5 +21,6 @@ godep go test eco/*
 go install github.com/azavea/ecobenefits
 cp -r data bin/data
 cp config.gcfg.template bin
+rm bin/godep
 
 cd bin && tar czf ecoservice.tar.gz --transform 's|^|ecoservice/|' *


### PR DESCRIPTION
During the build process, the `godep` binary was sneaking into the `bin` directory, which gets rolled up into a tarball for releases. This pull request attempts to delete the `godep` binary before a tarball is created.
