### PR TITLE
Read proxy address from an environment variable

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -3,10 +3,6 @@
 
 Vagrant.require_version ">= 1.5"
 
-def local_ip
-  `ipconfig getifaddr en0`.strip
-end
-
 # Uses the contents of roles.txt to ensure that ansible-galaxy is run if any
 # dependencies are missing.
 def install_dependent_roles


### PR DESCRIPTION
The previous version would fail if the vagrant-proxyconf plugin was installed but a proxy was not running.
