### PR TITLE
Fix error in adding up yearly results for scenario

### DIFF
--- a/ecorest/endpoints/eco_scenario.go
+++ b/ecorest/endpoints/eco_scenario.go
@@ -147,7 +147,7 @@ func EcoScenarioPOST(cache *cache.Cache) func(*ScenarioPostData) (*Scenario, err
 					diameter,
 					factorSum)
 				for j, value := range factorSum {
-					yearTotals[i][j] = value
+					yearTotals[i][j] += value
 					grandTotals[j] += value
 				}
 			}


### PR DESCRIPTION
For a given simulation year `i` and eco factor index `j`, `yearTotals[i][j]` is supposed to sum values for that eco factor for all simulated trees. But as written it was replacing rather than summing, and so was just giving the value for the final tree. Now it sums correctly.