### PR TITLE
Rename instance.bounds_obj

### DIFF
--- a/eco/db.go
+++ b/eco/db.go
@@ -97,7 +97,7 @@ func (dbc *DBContext) GetRegionsForInstance(
                           from treemap_instance
                              inner join treemap_instancebounds
                              on treemap_instancebounds.id =
-                             treemap_instance.bounds_obj_id
+                             treemap_instance.bounds_id
                              left join treemap_itreeregion
                              on st_intersects(
                                 treemap_itreeregion.geometry,


### PR DESCRIPTION
As part of a multiple commit, blue-green safe migration, instance.bounds
has been replaced with a one-to-one foreign key, bounds_obj, which is
now being renamed to bounds. Effectively, this "moves" instance.bounds
to another table.

See the commits on
https://github.com/OpenTreeMap/otm-core/commit/600f163eb0963e45cf0513515bb0d98e45077082
for more details.